### PR TITLE
Add missing parameter to lu1rec calls

### DIFF
--- a/src/lusol7b.f
+++ b/src/lusol7b.f
@@ -149,6 +149,7 @@
      $                   inform )
 
       implicit           double precision (a-h,o-z)
+      integer            ilast
       integer            luparm(30)
       double precision   parmlu(30), a(lena), c(m)
       integer            indc(lena), indr(lena), ip(m), iq(n), lenr(m)
@@ -214,7 +215,8 @@
          minfre = n + 1
          nfree  = lfree - lrow
          if (nfree .ge. minfre) go to 200
-         call lu1rec( m, .true., luparm, lrow, lena, a,indr,lenr,locr )
+         call lu1rec( m, .true., luparm, lrow, ilast, lena,
+     &                a, indr, lenr, locr )
          cmprss = .true.
          nfree  = lfree - lrow
          if (nfree .lt. minfre) go to 970

--- a/src/lusol8b.f
+++ b/src/lusol8b.f
@@ -96,6 +96,7 @@
      $                   inform, diag )
 
       implicit           double precision (a-h,o-z)
+      integer            ilast
       integer            luparm(30)
       double precision   parmlu(30), a(lena), w(n)
       integer            indc(lena), indr(lena), ip(m), iq(n)
@@ -139,7 +140,8 @@
       minfre = n
       nfree  = lena - lenl - lrow
       if (nfree .ge. minfre) go to 100
-      call lu1rec( m, .true., luparm, lrow, lena, a, indr, lenr, locr )
+      call lu1rec( m, .true., luparm, lrow, ilast, lena,
+     &             a, indr, lenr, locr )
       nfree  = lena - lenl - lrow
       if (nfree .lt. minfre) go to 970
 
@@ -522,6 +524,7 @@
      $                   inform )
 
       implicit           double precision (a-h,o-z)
+      integer            ilast
       integer            luparm(30)
       double precision   parmlu(30), a(lena), v(m), w(n)
       integer            indc(lena), indr(lena), ip(m), iq(n)
@@ -640,7 +643,8 @@
       minfre = n + 1 - kfirst
       nfree  = lfree - lrow
       if (nfree .ge. minfre) go to 310
-      call lu1rec( m, .true., luparm, lrow, lena, a, indr, lenr, locr )
+      call lu1rec( m, .true., luparm, lrow, ilast, lena,
+     &             a, indr, lenr, locr )
       nfree  = lfree - lrow
       if (nfree .lt. minfre) go to 970
 
@@ -678,7 +682,8 @@
          minfre = n
          nfree  = lfree - lrow
          if (nfree .ge. minfre) go to 420
-         call lu1rec( m, .true., luparm, lrow, lena, a,indr,lenr,locr )
+         call lu1rec( m, .true., luparm, lrow, ilast, lena,
+     &                a, indr, lenr, locr )
          nfree  = lfree - lrow
          if (nfree .lt. minfre) go to 970
 
@@ -700,7 +705,8 @@
          minfre = n
          nfree  = lfree - lrow
          if (nfree .ge. minfre) go to 500
-         call lu1rec( m, .true., luparm, lrow, lena, a,indr,lenr,locr )
+         call lu1rec( m, .true., luparm, lrow, ilast, lena,
+     &                a, indr, lenr, locr )
          nfree  = lfree - lrow
          if (nfree .lt. minfre) go to 970
 


### PR DESCRIPTION
Building with LTO (link-time optimization) triggers compiler warnings that some callers of lu1rec pass arguments that don't match the declared parameters.  Each such caller is missing the ilast parameter.  This patch adds the missing arguments.

A typical warning looks like this (building with gfortran on an x86_64 Fedora 37 machine):
```
src/lusol8b.f:643:72: warning: type of 'lu1rec' does not match original declaration [-Wlto-type-mismatch]
  643 |       call lu1rec( m, .true., luparm, lrow, lena, a, indr, lenr, locr )
      |                                                                        ^
src/lusol_util.f:3715:23: note: type mismatch in parameter 10
 3715 |       subroutine lu1rec( n, reals, luparm, ltop, ilast,
      |                       ^
src/lusol_util.f:3715:23: note: 'lu1rec' was previously declared here
src/lusol_util.f:3715:23: note: code may be misoptimized unless '-fno-strict-aliasing' is used
```
