### PR TITLE
Give zero a value before use in lu8mod

### DIFF
--- a/src/lusol8b.f
+++ b/src/lusol8b.f
@@ -557,6 +557,8 @@
 
       logical            singlr
 
+      parameter        ( zero = 0.0d+0 )
+
       nout   = luparm(1)
       lprint = luparm(2)
       nrank  = luparm(16)


### PR DESCRIPTION
Fixes this warning:
```
src/lusol8b.f: In function 'lu8mod_':
src/lusol8b.f:752:72: warning: 'zero' may be used uninitialized [-Wmaybe-uninitialized]
  752 |          diag   = zero
      |                                                                        ^
src/lusol8b.f:752:22: note: 'zero' was declared here
  752 |          diag   = zero
      |                      ^
```

Note that there is one other such problem in lusol8b.f.  I don't know how to fix this one:
```
src/lusol8b.f:761:21: warning: 'jrep' may be used uninitialized [-Wmaybe-uninitialized]
  761 |             if (.not. singlr) then
      |                     ^
src/lusol8b.f:759:33: note: 'jrep' was declared here
  759 |             singlr = j1 .ne. jrep
      |                                 ^
```

There is no parameter or local variable named jrep.