### PR TITLE
Fix race when building src/lusol.o

### DIFF
--- a/makefile
+++ b/makefile
@@ -144,7 +144,7 @@ $(F90_OBJ) : %.o : %.f90
 $(F90_MOD) : %.mod : %.o
 
 # extra fortran dependencies
-lusol.o : lusol_precision.mod
+src/lusol.o : src/lusol_precision.mod
 
 # C code generation
 src/clusol.h: $(INTERFACE_FILES)


### PR DESCRIPTION
Both `lusol.o` and `lusol_precision.mod` are in the src directory.  This fixes errors like this when invoking make with the `-j` option for parallel builds:
```
src/lusol.f90:54:8:
   54 |   use  lusol_precision,        only : ip, rp
      |        1
Fatal Error: Cannot open module file ‘lusol_precision.mod’ for reading at (1): No such file or directory
compilation terminated.
```
